### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module YAML::Tiny
 
+1.53 
+    - Updated format to conform to CPAN::Changes::Spec
+
 1.52 2013-08-20
     - updated repository metadata to reflect move to github
 


### PR DESCRIPTION
Hi,

I've reformatted this dist's Changes file to conform to CPAN::Changes::Spec:
- Changed all dates to ISO 8601 format
- Consistent identation and removed all tab characters

Normally I paste in some stuff here about how a consistent format makes it easy for tool writers and one-off script writers. I'm just happy to bag myself an ETHER release on my [quest](http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086) :-)

Cheers,
Neil

PS See how you're doing: http://changes.cpanhq.org/author/ETHER
