### PR TITLE
Embedded newlines

### DIFF
--- a/t/tml-local/yaml-roundtrip/scalar.tml
+++ b/t/tml-local/yaml-roundtrip/scalar.tml
@@ -64,6 +64,64 @@
 [ [ "foo\nbar", 1 ] ]
 
 
+# ... with embedded blank line
+=== block scalar with embedded blank line
++++ yaml
+---
+- |-
+  foo
+  
+  bar
+- 1
++++ perl
+[ [ "foo\n\nbar", 1 ] ]
+
+
+# ... with embedded and trailing blank lines (keep)
+=== block scalar keeps trailing blank lines
++++ yaml
+---
+- |+
+  foo
+  
+  bar
+  
+  
+- 1
++++ perl
+[ [ "foo\n\nbar\n\n\n", 1 ] ]
+
+
+# ... with embedded and trailing blank lines (clip)
+=== block scalar clips trailing blank lines
++++ yaml
+---
+- |
+  foo
+  
+  bar
+  
+  
+- 1
++++ perl
+[ [ "foo\n\nbar\n", 1 ] ]
+
+
+# ... with embedded and trailing blank lines (strip)
+=== block scalar strips trailing blank lines
++++ yaml
+---
+- |-
+  foo
+  
+  bar
+
+
+- 1
++++ perl
+[ [ "foo\n\nbar", 1 ] ]
+
+
 #####################################################################
 # Hitchhiker Scalar
 


### PR DESCRIPTION
I needed to embed newlines in a block literal scalar, so I have a patch and tests to do that. The main thing was to get the regex split at the top of `_read_scalar` not to eat blank lines; then the various read loops have to deal with them.

I worry that I misunderstand how you're supposed to handle leading spaces in the middle of those block literals. I don't try to catch those and let the existing code detect errors there.

This is my first pull request ever, so please be gentle. :)
