### PR TITLE
prevent warnings when Scalar::Util is missing or broken

### DIFF
--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -720,11 +720,10 @@ sub LoadFile {
 
 BEGIN {
     local $@;
-    eval {
-        require Scalar::Util;
-    };
-    my $v = eval("$Scalar::Util::VERSION") || 0;
-    if ( $@ or $v < 1.18 ) {
+    if ( eval { require Scalar::Util; Scalar::Util->VERSION(1.18); } ) {
+        *refaddr = *Scalar::Util::refaddr;
+    }
+    else {
         eval <<'END_PERL';
 # Scalar::Util failed to load or too old
 sub refaddr {
@@ -735,13 +734,11 @@ sub refaddr {
         $pkg = undef;
     }
     "$_[0]" =~ /0x(\w+)/;
-    my $i = do { local $^W; hex $1 };
+    my $i = do { no warnings 'portable'; hex $1 };
     bless $_[0], $pkg if defined $pkg;
     $i;
 }
 END_PERL
-    } else {
-        *refaddr = *Scalar::Util::refaddr;
     }
 }
 


### PR DESCRIPTION
YAML::Tiny used to not use warnings, and the Scalar::Util
detection/fallback code wasn't properly updated when warnings were
added.  This revises the version check and the fallback code to work
without warning.
