### PR TITLE
Remove eval around require Scalar::Util

### DIFF
--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -828,8 +828,9 @@ sub _can_flock {
 # Use Scalar::Util if possible, otherwise emulate it
 
 BEGIN {
+    require Scalar::Util;
     local $@;
-    if ( eval { require Scalar::Util; Scalar::Util->VERSION(1.18); } ) {
+    if ( eval { Scalar::Util->VERSION(1.18); } ) {
         *refaddr = *Scalar::Util::refaddr;
     }
     else {


### PR DESCRIPTION
The required version of perl is high enough that Scalar::Util should
always be present.  The eval is only needed because we are also checking
the version.  However, if Scalar::Util is broken for some reason, it's
better to die than silence the error.  If we silence the error, later
attempts to load it will only give "Attempting to reload Scalar/Util.pm
aborted", making diagnostics much harder.
