### PR TITLE
Drop minimum Test::More to 0.88 by emulating subtest

### DIFF
--- a/t/01_api.t
+++ b/t/01_api.t
@@ -4,7 +4,8 @@ use strict;
 use warnings;
 
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestBridge;
 use YAML::Tiny;
 

--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -8,7 +8,7 @@ BEGIN {
     $|  = 1;
 }
 
-use Test::More 0.99;
+use Test::More 0.88;
 
 # Check their perl version
 ok( $] ge '5.008001', "Your perl is new enough" );

--- a/t/10_read.t
+++ b/t/10_read.t
@@ -2,7 +2,8 @@ use strict;
 use warnings;
 use utf8;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestUtils;
 use TestBridge;
 

--- a/t/11_read_string.t
+++ b/t/11_read_string.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestUtils;
 use TestBridge;
 

--- a/t/12_write.t
+++ b/t/12_write.t
@@ -2,7 +2,8 @@ use utf8;
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestBridge;
 use TestUtils;
 

--- a/t/13_write_string.t
+++ b/t/13_write_string.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestUtils;
 use TestBridge;
 

--- a/t/20_subclass.t
+++ b/t/20_subclass.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
 use TestUtils;
 
 use File::Spec::Functions ':ALL';

--- a/t/21_yamlpm_compat.t
+++ b/t/21_yamlpm_compat.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
 use TestBridge;
 use File::Spec::Functions 'catfile';
 use File::Temp 0.19; # newdir

--- a/t/30_yaml_spec_tml.t
+++ b/t/30_yaml_spec_tml.t
@@ -2,7 +2,8 @@
 use strict;
 use warnings;
 use lib 't/lib';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use TestBridge;
 use TestUtils;
 
@@ -24,7 +25,6 @@ for my $test (@spec_tests) {
     my $code = sub {
         my ($file, $blocks) = @_;
         subtest "YAML Spec Test; file: $file" => sub {
-            plan tests => scalar @$blocks;
             my $func = \&{$bridge};
             $func->($_) for @$blocks;
         };

--- a/t/31_local_tml.t
+++ b/t/31_local_tml.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
 use TestBridge;
 use IO::Dir;
 use File::Spec::Functions qw/catdir/;

--- a/t/32_world_tml.t
+++ b/t/32_world_tml.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use lib 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
 use TestBridge;
 
 run_all_testml_files(

--- a/t/README.md
+++ b/t/README.md
@@ -19,10 +19,8 @@ of those modules as necessary to avoid known bugs.
 Some .t files have complete inputs/outputs for their tests.  Others iterate
 over .tml files in the t/tml-* directories.
 
-A .t file should load Test::More and either use `done_testing` or provide a
-test plan.  If tests iterate over external data, the use of `done_testing` is
-preferred so that external data can be updated with new tests without needing
-to also update a test plan.
+A .t file should load Test::More and use `done_testing` at the end
+to so that new tests may be added without needing to also update a test plan.
 
 Currently, the convention is to name .t files matching the pattern
 qr/^\d\d_\w+\.t$/
@@ -35,9 +33,15 @@ libraries can assume that if they were loaded, that 't/lib' is already in @INC.
 
 The test libraries are:
 
+* SubtestCompat
 * TestML::Tiny
 * TestBridge
 * TestUtils
+
+The "SubtestCompat" library provides a limited emulation of
+Test::More::subtest that is reasonably compatible back to 0.88.  If using
+subtests, you must not set a plan in the subtest and you must use
+done_testing in the *.t file.
 
 The TestML::Tiny library contains functions for parsing and executing TestML
 tests with callbacks.  TestML is a data-driven testing language; TestML::Tiny

--- a/t/lib/SubtestCompat.pm
+++ b/t/lib/SubtestCompat.pm
@@ -1,0 +1,66 @@
+use 5.008001;
+use strict;
+use warnings;
+
+package SubtestCompat;
+
+# XXX must be used with no_plan or done_testing
+use Test::More 0.88;
+
+use base 'Exporter';
+our @EXPORT;
+
+our $INDENT = -2;
+
+# intercept 'skip_all' in subtest and turn into a regular skip
+sub _fake_plan {
+    my ( $self, $cmd, $arg ) = @_;
+
+    return unless $cmd;
+
+    if ( $cmd eq 'skip_all' ) {
+        die bless { reason => $arg }, "Subtest::SKIP";
+    }
+    else {
+        goto &Test::Builder::plan;
+    }
+}
+
+unless ( Test::More->can("subtest") ) {
+    *subtest = sub {
+        my ( $label, $code ) = @_;
+        local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+        local $INDENT = $INDENT + 2;
+
+        $label = "TEST: $label";
+        my $sep_len = 60 - length($label);
+
+        note( " " x $INDENT . "$label { " . ( " " x ($sep_len-$INDENT-2) ) );
+        eval {
+            no warnings 'redefine';
+            local *Test::Builder::plan = \&_fake_plan;
+            # only want subtest error reporting to look up to the code ref
+            # for where test was called, not further up to *our* callers,
+            # so we *reset* the Level, rather than increment it
+            local $Test::Builder::Level = 1;
+            $code->();
+        };
+        if ( my $err = $@ ) {
+            if ( ref($err) eq 'Subtest::SKIP' ) {
+                SKIP: {
+                    skip $err->{reason}, 1;
+                }
+            }
+            else {
+                fail("SUBTEST: $label");
+                diag("Caught exception: $err");
+                die "$err\n";
+            }
+        }
+        note( " " x $INDENT . "}" );
+    };
+    push @EXPORT, 'subtest';
+}
+
+1;

--- a/t/lib/TestBridge.pm
+++ b/t/lib/TestBridge.pm
@@ -2,8 +2,9 @@ package TestBridge;
 
 use strict;
 use warnings;
-
-use Test::More 0.99;
+use lib 't/lib';
+use Test::More 0.88;
+use SubtestCompat;
 use TestUtils;
 use TestML::Tiny;
 
@@ -51,8 +52,7 @@ my %WARN = (
 # run_all_testml_files
 #
 # Iterate over all .tml files in a directory using a particular test bridge
-# code # reference.  Each file is wrapped in a subtest with a test plan
-# equal to the number of blocks.
+# code # reference.  Each file is wrapped in a subtest.
 #--------------------------------------------------------------------------#
 
 sub run_all_testml_files {
@@ -61,7 +61,6 @@ sub run_all_testml_files {
     my $code = sub {
         my ($file, $blocks) = @_;
         subtest "$label: $file" => sub {
-            plan tests => scalar @$blocks;
             $bridge->($_, @args) for @$blocks;
         };
     };

--- a/t/lib/TestML/Tiny.pm
+++ b/t/lib/TestML/Tiny.pm
@@ -4,7 +4,7 @@ package TestML::Tiny;
 $TestML::Tiny::VERSION = 0.000001;
 
 use Carp();
-use Test::More 0.99 ();
+use Test::More 0.88 ();
 
 # use XXX;
 

--- a/t/tml
+++ b/t/tml
@@ -2,7 +2,8 @@
 use strict;
 use warnings;
 use lib 'lib', 't/lib/';
-use Test::More 0.99;
+use Test::More 0.88;
+use SubtestCompat;
 use Getopt::Long qw/:config passthrough/;
 use List::Util qw/first/;
 use TestBridge;
@@ -42,7 +43,6 @@ sub main {
             sub {
                 my ($file, $blocks) = @_;
                 subtest "TestML dev runner: $file" => sub {
-                    plan tests => scalar @$blocks;
                     $BRIDGE_MAP{$bridge}->($_) for @$blocks;
                 };
                 done_testing;


### PR DESCRIPTION
This commit adds a compatibility shim that provides a subtest-like
function for Test::More 0.88 until subtest was added (circa 0.94, but
not really usable until at least 0.96).

The only major test change is that subtests can't have a plan anymore.
While it was nice to have a plan for test blocks loaded from data files,
it's not really necessary as long as the .t file itself has
done_testing.

