### PR TITLE
Fix for RT #56045 "... strips space after newline in verbatim blocks"

### DIFF
--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -373,7 +373,7 @@ sub _load_scalar {
     while ( @$lines ) {
         $lines->[0] =~ /^(\s*)/;
         last unless length($1) >= $indent->[-1];
-        push @multiline, substr(shift(@$lines), length($1));
+        push @multiline, substr(shift(@$lines), $indent->[-1]);
     }
 
     my $j = (substr($string, 0, 1) eq '>') ? ' ' : "\n";

--- a/t/30_yaml_spec_tml.t
+++ b/t/30_yaml_spec_tml.t
@@ -16,6 +16,7 @@ diag 'using JSON backend: ' . $JSON . ' ' . $JSON->VERSION
 # Each spec test will need a different bridge and arguments:
 my @spec_tests = (
     ['t/tml-spec/basic-data.tml', 'test_yaml_json', $JSON],
+    ['t/tml-spec/multiline.tml',  'test_yaml_json', $JSON],
     # This test is currently failing massively. We use LAST to only run what is
     # covered so far.
     ['t/tml-spec/unicode.tml', 'test_code_point'],  # uses JSON::PP

--- a/t/tml-spec/multiline.tml
+++ b/t/tml-spec/multiline.tml
@@ -1,0 +1,33 @@
+=== basic multiline
+# This is just a simple one key hash.
+--- yaml
+a: |
+   ciao
+   a tutti
+--- json
+{"a":"ciao\na tutti\n"}
+
+=== multiline with inner indentation
+# This is just a simple one key hash.
+--- yaml
+a: |
+   ciao
+         a
+   tutti
+--- json
+{"a":"ciao\n      a\ntutti\n"}
+
+=== two multilines with variable inner indentation
+# This is just a simple one key hash.
+--- yaml
+- |
+   ciao
+         a
+      tutti
+- |
+      quanti
+         voi
+      amici
+--- json
+["ciao\n      a\n   tutti\n","quanti\n   voi\namici\n"]
+


### PR DESCRIPTION
Fix for correct stripping of leading white space in literal/folded text blocks (see [RT #56045](https://rt.cpan.org/Public/Bug/Display.html?id=56045)).

The starting implementation eats up all the leading whitespace in the line, not only the amount given by the initial non-empty line as it should.
