### PR TITLE
Catch sysopen errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for YAML-Tiny
 
 {{$NEXT}}
 
+        [FIXED]
+
+        - Some errors writing to a file were incorrectly reported.
+
 1.69    2015-07-26 00:51:03Z
         - No changes since 1.68-TRIAL.
 

--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -569,10 +569,8 @@ sub _dump_file {
     if ( _can_flock() ) {
         # Open without truncation (truncate comes after lock)
         my $flags = Fcntl::O_WRONLY()|Fcntl::O_CREAT();
-        sysopen( $fh, $file, $flags );
-        unless ( $fh ) {
-            $self->_error("Failed to open file '$file' for writing: $!");
-        }
+        sysopen( $fh, $file, $flags )
+            or $self->_error("Failed to open file '$file' for writing: $!");
 
         # Use no translation and strict UTF-8
         binmode( $fh, ":raw:encoding(UTF-8)");


### PR DESCRIPTION
I observed some situations where sysopen would fail, but leave the file
handle defined.  This would lead to an error later when binmode or locking
fails on a closed filehandle.

This commit checks the return value of sysopen directly.
