### PR TITLE
fix compatibility with Test::Builder 0.94

### DIFF
--- a/t/lib/SubtestCompat.pm
+++ b/t/lib/SubtestCompat.pm
@@ -62,5 +62,18 @@ unless ( Test::More->can("subtest") ) {
     };
     push @EXPORT, 'subtest';
 }
+elsif ( !eval { Test::More->VERSION(0.95_01) } ) {
+    my $subtest = \&Test::Builder::subtest;
+    no warnings 'redefine';
+    *Test::Builder::subtest = sub {
+        my ($self, $name, $subtests, @args) = @_;
+        my $sub = sub {
+            $subtests->(@_);
+            $self->done_testing
+                unless $self->{Have_Plan} || $self->{No_Plan} || $self->{Skip_All};
+        };
+        return $self->$subtest($name, $sub, @args);
+    };
+}
 
 1;


### PR DESCRIPTION
Test::Builder 0.94 supports subtests, but requires an explicit plan or
done_testing.  We have a compatibility shim for versions without
subtests, but it doesn't handle plans or done_testing, so we don't want
to add those calls to our tests.

Apply a wrapper to subtest that automatically calls done_testing inside
the subtest, like 0.96+ does.

Fixes #49