### PR TITLE
fix error with hash keys beginning with '-'

### DIFF
--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -528,7 +528,7 @@ sub _load_hash {
                 $hash->{$key} = undef;
                 return 1;
             }
-            if ( $lines->[0] =~ /^(\s*)-/ ) {
+            if ( $lines->[0] =~ /^(\s*)-(?:\s|$)/ ) {
                 $hash->{$key} = [];
                 $self->_load_array(
                     $hash->{$key}, [ @$indent, length($1) ], $lines

--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -528,7 +528,7 @@ sub _load_hash {
                 $hash->{$key} = undef;
                 return 1;
             }
-            if ( $lines->[0] =~ /^(\s*)-(?:\s|$)/ ) {
+            if ( $lines->[0] =~ /^(\s*)-(?:[ \t]|$)/ ) {
                 $hash->{$key} = [];
                 $self->_load_array(
                     $hash->{$key}, [ @$indent, length($1) ], $lines

--- a/t/10_read.t
+++ b/t/10_read.t
@@ -34,6 +34,12 @@ my %passes = (
         ],
         utf8 => 'author',
     },
+    'hash with key' => {
+        file => 'font-data.yml',
+        perl => [
+            { font => { -family => 'Courier 10 Pitch', -overstrike => 0 } }
+        ]
+    }
 );
 
 for my $key ( sort keys %passes ) {

--- a/t/data/font-data.yml
+++ b/t/data/font-data.yml
@@ -1,0 +1,4 @@
+---
+font:
+  -family: 'Courier 10 Pitch'
+  -overstrike: 0


### PR DESCRIPTION
Hello

YAML::Tiny fails to parse a hash where the key begins with '-' (e.g. '-foo'). YAML::Tiny fails with:
```
YAML::Tiny found illegal characters in plain scalar: 'family: 'Courier 10 Pitch'' at test-yaml.pl line 21.
```

This PR contains a fix to this problem and a new test case for this style of hash keys.

Here's the test program that triggers this error:

```
$ cat test-yaml.pl
use strict;
use warnings;
use YAML::Tiny;
use XXX;

YYY (YAML::Tiny->read('test.yml') );
```

The yaml file:
```
$ cat test.yml
---
font:
  -family: 'Courier 10 Pitch'
  -overstrike: 0
  -size: -13
  -slant: roman
  -underline: 0
  -weight: normal
```

The result of the script with current version of YAML::Tiny:

```
$ perl test-yaml.pl
YAML::Tiny found illegal characters in plain scalar: 'family: 'Courier 10 Pitch'' at test-yaml.pl line 6.
```

And the result with the patch:
```
$ perl -Ilib test-yaml.pl
--- !!perl/array:YAML::Tiny
- font:
    -family: Courier 10 Pitch
    -overstrike: 0
    -size: -13
    -slant: roman
    -underline: 0
    -weight: normal
...
  at test-yaml.pl line 6
  ```

This patch also fixes [RT #85045](https://rt.cpan.org/Public/Bug/Display.html?id=85045)

All the best
