### PR TITLE
Revert back to old boolean escaping behavior

### DIFF
--- a/lib/YAML/Tiny.pm
+++ b/lib/YAML/Tiny.pm
@@ -138,7 +138,10 @@ my %UNESCAPES = (
 # These 3 values have special meaning when unquoted and using the
 # default YAML schema. They need quotes if they are strings.
 my %QUOTE = map { $_ => 1 } qw{
-    null true false
+    null Null NULL
+    y Y yes Yes YES n N no No NO
+    true True TRUE false False FALSE
+    on On ON off Off OFF
 };
 
 # The commented out form is simpler, but overloaded the Perl regex

--- a/t/lib/TestBridge.pm
+++ b/t/lib/TestBridge.pm
@@ -347,11 +347,13 @@ sub test_code_point {
         my $data = { chr($code) => chr($code) };
         my $dump = YAML::Tiny::Dump($data);
         $dump =~ s/^---\n//;
-        is $dump, $yaml, "Dump key and value of code point char $code";
+        ok($dump eq $yaml or "'$dump'" eq $yaml,
+            "Dump key and value of code point char $code");
 
         my $yny = YAML::Tiny::Dump(YAML::Tiny::Load($yaml));
         $yny =~ s/^---\n//;
-        is $yny, $yaml, "YAML for code point $code YNY roundtrips";
+        ok($yny eq $yaml or "'$yny'" eq $yaml,
+            "YAML for code point $code YNY roundtrips");
 
         my $nyn = YAML::Tiny::Load(YAML::Tiny::Dump($data));
         cmp_deeply( $nyn, $data, "YAML for code point $code NYN roundtrips" );


### PR DESCRIPTION
The commit b18746009c20a2d040e2c02b78a878480c3b2859 introduced a regression (for our use-case at least) by changing `%QUOTE`.

It used to be that all "special" YAML keywords (null, true, false, yes, no, etc.) would be quoted to avoid `Dump("yes") eq "---\nyes"` since YAML `yes` is a boolean, not a string.

For some reason, the commit silently changed that behavior to /only/ escape `null`, `true`, and `false`. I cannot find any rationale for it, as `yes` is equivalent to `true` so why would only one of them be quoted?

---

I also fixed the tests, but I'm no perl expert and there might be a more idiomatic way to go about this.