### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/t/01_compile.t
+++ b/t/01_compile.t
@@ -11,7 +11,7 @@ BEGIN {
 use Test::More 0.88;
 
 # Check their perl version
-ok( "$]" ge '5.008001', "Your perl is new enough" );
+ok( "$]" >= 5.008001, "Your perl is new enough" );
 
 # Does the module load
 require_ok( 'YAML::Tiny' );


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.